### PR TITLE
Fix spelling of Enumerable

### DIFF
--- a/src/GenFu/ValueGenerators/EnumerableExtensions.cs
+++ b/src/GenFu/ValueGenerators/EnumerableExtensions.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace GenFu
 {
-    static class EnnumerableExtensions
+    static class EnumerableExtensions
     {
         private static Random _random = new Random();
         public static int GetRandomIndex(this IEnumerable<string> list)


### PR DESCRIPTION
EnumerableExtensions had misspelling / typo (was EnnumerableExtensions)
